### PR TITLE
Extend example.pl a bit

### DIFF
--- a/example.pl
+++ b/example.pl
@@ -7,3 +7,15 @@ say color('underline red on_yellow'),
 	"Hey, isn't it awesome?", color('reset');
 say colored("IM IN UR MODULE MESSING WITH UR COLOURS",
 			"bold green on_blue");
+
+# 256-color support: '196 on_54'
+my $psych = "Yo, I got your psychedelia right here!"
+    .words.map({ colored("$_ ", "{(^256).pick} on_{(^256).pick}") }).join;
+say $psych;
+say colorstrip($psych);
+
+# 24-bit support
+my $escapes = color('255,255,0 on_187,0,0');
+my $description = uncolor($escapes);
+say "'$description' encodes to:";
+say $escapes.perl;


### PR DESCRIPTION
* Show use of 256-color and 24-bit color extensions
* Show use of colorstrip() and uncolor()