### PR TITLE
Split on whitespace more liberally

### DIFF
--- a/lib/Terminal/ANSIColor.pm
+++ b/lib/Terminal/ANSIColor.pm
@@ -39,7 +39,7 @@ my %attrs =
 
 sub color (Str $what) is export {
 	my @res;
-	my @a = $what.split(' ');
+	my @a = $what.words;
 	for @a -> $attr {
 		if %attrs{$attr}:exists {
 			@res.push: %attrs{$attr}


### PR DESCRIPTION
So you could write stuff like this and have it actually align:

```perl6
    {colored '█' x $text.chars, 'yellow bold'}
    {colored       $text,       'green  bold'}
    {colored '█' x $text.chars, 'yellow bold'}
```

Currently, the above dies with `Invalid attribute name ''`