### PR TITLE
Add italic to attrs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp

--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
     "perl"        : "6.*",
     "name"        : "Terminal::ANSIColor",
     "license"     : "MIT",
-    "version"     : "0.4",
+    "version"     : "0.5",
     "description" : "Colorize terminal output",
     "build-depends" : [ ],
     "test-depends" : [

--- a/lib/Terminal/ANSIColor.pm
+++ b/lib/Terminal/ANSIColor.pm
@@ -5,17 +5,18 @@ unit module Terminal::ANSIColor;
 # these will be macros one day, yet macros can't be exported so far
 sub RESET         is export { "\e[0m"  }
 sub BOLD          is export { "\e[1m"  }
+sub ITALIC        is export { "\e[3m"  }
 sub UNDERLINE     is export { "\e[4m"  }
 sub INVERSE       is export { "\e[7m"  }
 sub BOLD_OFF      is export { "\e[22m" }
+sub ITALIC_OFF    is export { "\e[23m"  }
 sub UNDERLINE_OFF is export { "\e[24m" }
 sub INVERSE_OFF   is export { "\e[27m" }
-sub ITALIC        is export { "\e[3m"  }
-sub ITALIC_OFF    is export { "\e[23m"  }
 
 my %attrs =
 	reset      => "0",
 	bold       => "1",
+	italic     => "3",
 	underline  => "4",
 	inverse    => "7",
 	black      => "30",


### PR DESCRIPTION
`italic` was not accessible via the `color()` sub, because it was not included in `%attrs`. This PR should solve that.