### PR TITLE
Fill in missing SGR attributes, update docs, and add self to authors

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -30,6 +30,7 @@
     "ESCAPE"
   ],
   "test-depends": [
+    "Test::Coverage"
   ],
   "version": "0.13"
 }

--- a/META6.json
+++ b/META6.json
@@ -25,6 +25,8 @@
     "TERM",
     "COLOR",
     "ANSI",
+    "ECMA-48",
+    "SGR",
     "ESCAPE"
   ],
   "test-depends": [

--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,8 @@
   "auth": "zef:raku-community-modules",
   "authors": [
     "Tadeusz “tadzik” Sośnierz",
-    "Elizabeth Mattijsen"
+    "Elizabeth Mattijsen",
+    "Geoffrey Broadwell"
   ],
   "build-depends": [
   ],

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ AUTHORS
 
   * Elizabeth Mattijsen
 
+  * Geoffrey Broadwell
+
 Source can be located at: https://github.com/raku-community-modules/Terminal-ANSIColor . Comments and Pull Requests are welcome.
 
 COPYRIGHT AND LICENSE

--- a/README.md
+++ b/README.md
@@ -29,11 +29,22 @@ color
 
 Given a string with color names, the output produced by `color()` sets the terminal output so the text printed after it will be colored as specified. The following color names are recognised:
 
-    reset bold italic underline inverse
-    bold_off italic_off underline_off inverse_off
-    black red green yellow blue magenta cyan white
-    default on_black on_red on_green on_yellow
-    on_blue on_magenta on_cyan on_white on_default
+    reset bold faint italic blink inverse conceal
+    strike underline dunderline overline
+
+    bold_off italic_off blink_off inverse_off conceal_off
+    strike_off underline_off overline_off
+
+    black red green yellow blue magenta cyan white default
+
+    on_black on_red on_green on_yellow on_blue
+    on_magenta on_cyan on_white on_default
+
+Note a few special cases:
+
+  * `reset`         - Turns off all other attributes/colors
+  * `bold_off`      - Turns off both `bold` and `faint`
+  * `underline_off` - Turns off both `underline` and `dunderline` (double underline)
 
 The on_* family of colors correspond to the background colors. One or three numeric color values in the range 0..255 may also be specified:
 
@@ -68,8 +79,18 @@ Constants
 
 `Terminal::ANSIColor` provides constants which are just strings of appropriate escape sequences. The following constants are available:
 
-    RESET BOLD ITALIC UNDERLINE INVERSE
-    BOLD_OFF ITALIC_OFF UNDERLINE_OFF INVERSE_OFF
+    RESET BOLD FAINT ITALIC BLINK INVERSE CONCEAL
+    STRIKE UNDERLINE DUNDERLINE OVERLINE
+
+    BOLD_OFF ITALIC_OFF BLINK_OFF INVERSE_OFF CONCEAL_OFF
+    STRIKE_OFF UNDERLINE_OFF OVERLINE_OFF
+
+As with the equivalents used by `color()`:
+
+  * `RESET`         - Turns off all other attributes/colors
+  * `BOLD_OFF`      - Turns off both `BOLD` and `FAINT`
+  * `UNDERLINE_OFF` - Turns off both `UNDERLINE` and `DUNDERLINE` (double underline)
+
 
 AUTHORS
 =======

--- a/lib/Terminal/ANSIColor.rakumod
+++ b/lib/Terminal/ANSIColor.rakumod
@@ -3,35 +3,63 @@ unit module Terminal::ANSIColor;
 # these will be macros one day, yet macros can't be exported so far
 my constant RESET         is export = "\e[0m";
 my constant BOLD          is export = "\e[1m";
+my constant FAINT         is export = "\e[2m";
 my constant ITALIC        is export = "\e[3m";
 my constant UNDERLINE     is export = "\e[4m";
+my constant BLINK         is export = "\e[5m";
 my constant INVERSE       is export = "\e[7m";
+my constant CONCEAL       is export = "\e[8m";
+my constant STRIKE        is export = "\e[9m";
+my constant DUNDERLINE    is export = "\e[21m";
 my constant BOLD_OFF      is export = "\e[22m";
 my constant ITALIC_OFF    is export = "\e[23m";
 my constant UNDERLINE_OFF is export = "\e[24m";
+my constant BLINK_OFF     is export = "\e[25m";
 my constant INVERSE_OFF   is export = "\e[27m";
+my constant CONCEAL_OFF   is export = "\e[28m";
+my constant STRIKE_OFF    is export = "\e[29m";
+my constant OVERLINE      is export = "\e[53m";
+my constant OVERLINE_OFF  is export = "\e[55m";
 
 # legacy interface
 my sub RESET()         is export { "\e[0m"  }
 my sub BOLD()          is export { "\e[1m"  }
+my sub FAINT()         is export { "\e[2m"  }
 my sub ITALIC()        is export { "\e[3m"  }
 my sub UNDERLINE()     is export { "\e[4m"  }
+my sub BLINK()         is export { "\e[5m"  }
 my sub INVERSE()       is export { "\e[7m"  }
+my sub CONCEAL()       is export { "\e[8m"  }
+my sub STRIKE()        is export { "\e[9m"  }
+my sub DUNDERLINE()    is export { "\e[21m" }
 my sub BOLD_OFF()      is export { "\e[22m" }
 my sub ITALIC_OFF()    is export { "\e[23m" }
 my sub UNDERLINE_OFF() is export { "\e[24m" }
+my sub BLINK_OFF()     is export { "\e[25m" }
 my sub INVERSE_OFF()   is export { "\e[27m" }
+my sub CONCEAL_OFF()   is export { "\e[28m" }
+my sub STRIKE_OFF()    is export { "\e[29m" }
+my sub OVERLINE()      is export { "\e[53m" }
+my sub OVERLINE_OFF()  is export { "\e[55m" }
 
 my constant %attrs =
   reset         => "0",
   bold          => "1",
+  faint         => "2",
   italic        => "3",
   underline     => "4",
+  blink         => "5",
   inverse       => "7",
+  conceal       => "8",
+  strike        => "9",
+  dunderline    => "21",
   bold_off      => "22",
   italic_off    => "23",
   underline_off => "24",
+  blink_off     => "25",
   inverse_off   => "27",
+  conceal_off   => "28",
+  strike_off    => "29",
   black         => "30",
   red           => "31",
   green         => "32",
@@ -50,6 +78,8 @@ my constant %attrs =
   on_cyan       => "46",
   on_white      => "47",
   on_default    => "49",
+  overline      => "53",
+  overline_off  => "55",
 ;
 
 my constant %inverted = %attrs.kv.reverse;


### PR DESCRIPTION
Terminal::ANSIColor was missing a fair number of standard SGR style attributes.  These may not have been well-supported by terminal emulators back when the module was first created, but they are now (I tested), so we should support them.

I've updated the docs accordingly, including adding some clarifications about _OFF codes that turn off more than one base attribute, such as UNDERLINE_OFF which turns off _both_ single and double underline.

Finally, at some point the blame data for my previous contributions (e.g. 8- and 24-bit color) was lost ... between those and the current set, give myself credit again by adding myself to the AUTHORS lists.
 